### PR TITLE
r/aws_elasticache_replication_group: Add support for `transit_encryption_mode` and enabling transit encryption on existing groups

### DIFF
--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -212,6 +212,7 @@ The following arguments are optional:
 * `subnet_group_name` - (Optional) Name of the cache subnet group to be used for the replication group.
 * `tags` - (Optional) Map of tags to assign to the resource. Adding tags to this resource will add or overwrite any existing tags on the clusters in the replication group and not to the group itself. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `transit_encryption_enabled` - (Optional) Whether to enable encryption in transit.
+* `transit_encryption_mode` - (Optional) Valid values are `preferred` or `required`. When enabling encryption on an existing replication group, you must first set this to `preferred` before you can set it to `required`. Required when `transit_encryption_enabled` is `true`.
 * `user_group_ids` - (Optional) User Group ID to associate with the replication group. Only a maximum of one (1) user group ID is valid. **NOTE:** This argument _is_ a set because the AWS specification allows for multiple IDs. However, in practice, AWS only allows a maximum size of one.
 
 ### Log Delivery Configuration


### PR DESCRIPTION
Hello, is opentofu accepting contributions yet? I can't find any discussion on whether or not you do.

Anyway, here's a change that I have been trying to submit to hashicorp (https://github.com/hashicorp/terraform-provider-aws/pull/30403) but there has been zero movement in 262 days, so I figured I'll try here as well. This PR was opened well before the licensing change so I think it should be all clear for you to merge.

Please let me know if you want any changes. Thanks!

---


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

I don't know if my fix for https://github.com/hashicorp/terraform-provider-aws/issues/30402 is good or not since there might be a better way to do it that I did not find. It is working in my simple test case though.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/30402
Closes https://github.com/hashicorp/terraform-provider-aws/issues/30700
Closes https://github.com/hashicorp/terraform-provider-aws/issues/33906

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

Here's the various errors that you can get.

If you try to enable encryption on an older Redis version:

> Error: updating ElastiCache Replication Group (tftest-redis): InvalidParameterCombination: Transit encryption mode is not supported for engine version 6.2.6. Please use engine version 7.0.5 or higher.

Have to set `transit_encryption_mode` when enabling encryption:

> Error: updating ElastiCache Replication Group (tftest-redis): InvalidParameterCombination: To modify transit encryption, please specify transit-encryption-mode.

Can't go straight to `transit_encryption_mode = "required"`:

> Error: updating ElastiCache Replication Group (tftest-redis): InvalidParameterCombination: Direct transition from transit-encryption-disabled to transit-encryption-enabled is not allowed. Update the cluster to transit-encryption-mode preferred prior to enabling transit encryption.


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I don't have time to work on updating the acceptance tests at the moment.
